### PR TITLE
Fix gray badge for above 97% code coverage in lcov-badge2

### DIFF
--- a/src/color.spec.ts
+++ b/src/color.spec.ts
@@ -21,7 +21,7 @@ describe('color', () => {
         });
 
         describe('When the input is one of the basic colors', () => {
-            for (const [ name, color ] of Object.entries(basicColors)) {
+            for (const [name, color] of Object.entries(basicColors)) {
                 test(`it accepts basic color "${name}"`, () => {
                     expect(getColorCode(color)).toBe(color.toLowerCase());
                 });

--- a/src/color.spec.ts
+++ b/src/color.spec.ts
@@ -1,4 +1,4 @@
-import { getColorCode } from './color';
+import { getColorCode, basicColors } from './color';
 
 describe('color', () => {
     describe('getColorCode()', () => {
@@ -10,6 +10,22 @@ describe('color', () => {
             test('it accepts a 6-digit value with a leading #', () => {
                 expect(getColorCode('#123456')).toBe('#123456');
             });
+
+            test('it accepts a 3-digit value', () => {
+                expect(getColorCode('123')).toBe('#123');
+            });
+
+            test('it accepts a 3-digit value with a leating #', () => {
+                expect(getColorCode('#123')).toBe('#123');
+            });
+        });
+
+        describe('When the input is one of the basic colors', () => {
+            for (const [ name, color ] of Object.entries(basicColors)) {
+                test(`it accepts basic color "${name}"`, () => {
+                    expect(getColorCode(color)).toBe(color);
+                });
+            }
         });
 
         describe('When the input is a color name', () => {

--- a/src/color.spec.ts
+++ b/src/color.spec.ts
@@ -15,7 +15,7 @@ describe('color', () => {
                 expect(getColorCode('123')).toBe('#123');
             });
 
-            test('it accepts a 3-digit value with a leating #', () => {
+            test('it accepts a 3-digit value with a leading #', () => {
                 expect(getColorCode('#123')).toBe('#123');
             });
         });
@@ -23,7 +23,7 @@ describe('color', () => {
         describe('When the input is one of the basic colors', () => {
             for (const [ name, color ] of Object.entries(basicColors)) {
                 test(`it accepts basic color "${name}"`, () => {
-                    expect(getColorCode(color)).toBe(color);
+                    expect(getColorCode(color)).toBe(color.toLowerCase());
                 });
             }
         });

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,6 +1,6 @@
 import colors from 'css-color-names';
 
-const COLOR_REGEX = /^#?[0-9a-f]{3,6}$/i;
+const COLOR_REGEX = /^#?[0-9a-f]{3|6}$/i;
 
 export const basicColors = {
     brightgreen: '#4C1',

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,6 +1,6 @@
 import colors from 'css-color-names';
 
-const COLOR_REGEX = /^#?[0-9a-f]{6}$/i;
+const COLOR_REGEX = /^#?[0-9a-f]{3,6}$/i;
 
 export const basicColors = {
     brightgreen: '#4C1',

--- a/src/color.ts
+++ b/src/color.ts
@@ -1,6 +1,6 @@
 import colors from 'css-color-names';
 
-const COLOR_REGEX = /^#?[0-9a-f]{3|6}$/i;
+const COLOR_REGEX = /^#?[0-9a-f]{3,6}$/i;
 
 export const basicColors = {
     brightgreen: '#4C1',


### PR DESCRIPTION
For anything higher than 97% coverage, the color picker fails. The `COLOR_REGEX` in `color.ts` fails to take less than 6 characters into account even though the `brightgreen` in the `basicColors` table in the same file consists of only 3 characters. Changing the `basicColor` from `#4C1` to `#44CC11` or changing the regex from `^#?[0-9a-f]{6}$` to `^#?[0-9a-f]{3,6}$` should both fix the issue. This would fix the badge being gray in `lcov-badge2` when coverage is above 97%.